### PR TITLE
Some small fixes for compatibility with ejabberd 19+

### DIFF
--- a/src/mod_offline_post.erl
+++ b/src/mod_offline_post.erl
@@ -15,7 +15,7 @@
 
 -define(PROCNAME, ?MODULE).
 
--include("ejabberd.hrl").
+%-include("ejabberd.hrl").
 %-include("jlib.hrl").
 -include("xmpp.hrl").
 -include("logger.hrl").
@@ -40,6 +40,9 @@ stop(Host) ->
     ok.
 
 depends(_Host, _Opts) ->
+    [].
+
+mod_options(_Host) ->
     [].
 
 mod_opt_type(post_url) -> fun(B) when is_binary(B) -> B end;


### PR DESCRIPTION
ejabberd.hrl was removed: https://github.com/processone/ejabberd/commit/fd8e07af4789be362a61755ea47f216baeb64989

Add mod_options(_Host) - warning removed